### PR TITLE
Fix Geyser.Mapper for mapper in hidden container

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -19,7 +19,7 @@ Geyser.Mapper.parent = Geyser.Window
 
 -- Overridden reposition function - mapper does it differently right now
 function Geyser.Mapper:reposition()
-  if self.hidden then
+  if self.hidden or self.auto_hidden then
     return
   end
   createMapper(self:get_x(), self:get_y(), self:get_width(), self:get_height())


### PR DESCRIPTION
Fixed the reposition function for Geyser.Mapper so that when the mapper is in a container that is hidden, and the container is resized or moved, the mapper remains hidden, rather than reappearing.

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
